### PR TITLE
Update billing-faq.md

### DIFF
--- a/billing-faq.md
+++ b/billing-faq.md
@@ -148,13 +148,6 @@ Business Continuity Insurance is insurance that protects you from illegitimate c
 
 To receive the credits for illegitimate charges against your servers, contact [{{site.data.keyword.Bluemix_notm}} Support](/unifiedsupport/supportcenter){: external} and open a support case.
 
-
-## What is the `Service: Support and Services` charge on my invoice?
-{: #supserve-invoice}
-{: faq}
-
-If you create a VMWare cluster on your {{site.data.keyword.Bluemix_notm}} account, you are charged for VMWare Level 2 Support for each cluster instance. This charge is in addition to any {{site.data.keyword.Bluemix_notm}} Support charges for Premium or Advanced Support.
-
 ## What's the difference between promo codes and feature codes?
 {: #promo-feature-codes}
 {: faq}


### PR DESCRIPTION
I have removed this FAQ https://cloud.ibm.com/docs/billing-usage?topic=billing-usage-billusagefaqs#supserve-invoice because these charges will no longer be added to a Client's invoice. I raised a Aha request asking the team to rename the above item on an invoice as it was causing confusion with out "paid support" clients https://bigblue.aha.io/features/VMWPLAT-898?utm_source=notification_mailer&utm_medium=email&utm_campaign=instant_email&active_tab=comments This was closed by the team in March because the text change was no longer needed as the line item will not be used. Therefore we no longer need this FAQ for Clients.  Feel free to reach out and validate with myself if required. Thanks, Claire Marked No Longer Needed since VCF re-pricing project will eliminate S&S per host fee.